### PR TITLE
add flag to optionally block ec2 metadata proxy

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the ec2 metadata")
 	fs.BoolVar(&s.AddIPTablesRule, "iptables", false, "Add iptables rule (also requires --host-ip)")
+	fs.BoolVar(&s.BlockEC2Metadata, "block-ec2-metadata", false, "Disable catch all reverse proxy")
 	fs.BoolVar(&s.AutoDiscoverBaseArn, "auto-discover-base-arn", false, "Queries EC2 Metadata to determine the base ARN")
 	fs.BoolVar(&s.AutoDiscoverDefaultRole, "auto-discover-default-role", false, "Queries EC2 Metadata to determine the default Iam Role and base ARN, cannot be used with --default-role, overwrites any previous setting for --base-role-arn")
 	fs.StringVar(&s.HostInterface, "host-interface", "docker0", "Host interface for proxying AWS metadata")


### PR DESCRIPTION
Some cluster administrators may not want tenants to be able to access non-iam aspects of the [ec2 metadata api](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) (eg; http://169.254.169.254/latest/user-data).

This change continues to route requests through the reverseProxyHandler by default but allows administrators to disable that functionality:

```
containers:
    - image: jtblin/kube2iam:dev
      name: kube2iam
      args:
      - "--block-ec2-metadata=true"
```