### PR TITLE
Include the externalID in the cache key

### DIFF
--- a/iam/iam.go
+++ b/iam/iam.go
@@ -128,7 +128,8 @@ func (iam *Client) EndpointFor(service, region string, optFns ...func(*endpoints
 // AssumeRole returns an IAM role Credentials using AWS STS.
 func (iam *Client) AssumeRole(roleARN, externalID string, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
 	hitCache := true
-	item, err := cache.Fetch(roleARN, sessionTTL, func() (interface{}, error) {
+	cacheKey := fmt.Sprintf("externalID/%s/roleARN/%s", externalID, roleARN)
+	item, err := cache.Fetch(cacheKey, sessionTTL, func() (interface{}, error) {
 		hitCache = false
 
 		// Set up a prometheus timer to track the AWS request duration. It stores the timer value when


### PR DESCRIPTION
#### What this PR does / why we need it:

This fixes a bug in the role caching where the `externalID` is not considered in the cache key.